### PR TITLE
Process metadata envelopes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,4 @@ All environment variables must be specified.
 * `ASSET_DIR` Root of a directory tree containing assets to be uploaded.
 * `CONTENT_SERVICE_URL` Root URL of the content service.
 * `CONTENT_SERVICE_APIKEY` Valid API key for the content service, issued by an administrator.
+* `CONTENT_ID_BASE` Content ID prefix common to the envelopes found in the envelope directory.

--- a/submitter/asset.py
+++ b/submitter/asset.py
@@ -57,10 +57,10 @@ class AssetSet():
     """
 
     def __init__(self):
-        self.assets = []
+        self.assets = {}
 
     def append(self, asset):
-        self.assets.append(asset)
+        self.assets[asset.localpath] = asset
 
     def fingerprint_query(self):
         """
@@ -70,14 +70,14 @@ class AssetSet():
         https://github.com/deconst/content-service#get-checkassets
         """
 
-        return {a.localpath: a.fingerprint for a in self.assets}
+        return {localpath: a.fingerprint for localpath, a in self.assets.items()}
 
     def accept_urls(self, response):
         """
         Update Asset states with the response of a /checkassets query.
         """
 
-        for asset in self.assets:
+        for asset in self.all():
             asset.accept_url(response)
 
     def to_upload(self):
@@ -85,7 +85,7 @@ class AssetSet():
         Generate each Asset that must be uploaded to the content service.
         """
 
-        for asset in self.assets:
+        for asset in self.all():
             if asset.needs_upload():
                 yield asset
 
@@ -94,7 +94,7 @@ class AssetSet():
         Generate all Assets.
         """
 
-        for asset in self.assets:
+        for asset in self.assets.values():
             yield asset
 
     def all_public(self):
@@ -104,6 +104,9 @@ class AssetSet():
 
         exhausted = object()
         return next(self.to_upload(), exhausted) is exhausted
+
+    def __getitem__(self, localpath):
+        return self.assets[localpath]
 
     def __len__(self):
         return len(self.assets)

--- a/submitter/config.py
+++ b/submitter/config.py
@@ -10,9 +10,13 @@ class Config:
         self.asset_dir = env.get('ASSET_DIR')
         self.content_service_url = env.get('CONTENT_SERVICE_URL')
         self.content_service_apikey = env.get('CONTENT_SERVICE_APIKEY')
+        self.content_id_base = env.get('CONTENT_ID_BASE')
 
         if self.content_service_url.endswith('/'):
             self.content_service_url = self.content_service_url[:-1]
+
+        if self.content_id_base and not self.content_id_base.endswith('/'):
+            self.content_id_base += '/'
 
     def missing(self):
         m = []
@@ -24,6 +28,8 @@ class Config:
             m.append('CONTENT_SERVICE_URL')
         if not self.content_service_apikey:
             m.append('CONTENT_SERVICE_APIKEY')
+        if not self.content_id_base:
+            m.append('CONTENT_ID_BASE')
         return m
 
     def is_valid(self):

--- a/submitter/content_service.py
+++ b/submitter/content_service.py
@@ -42,7 +42,7 @@ class ContentService():
         Bulk-upload a binary buffer containing multiple assets within a
         .tar.gz file.
 
-        https://github.com/deconst/content-service#post-bulkassets
+        https://github.com/deconst/content-service#post-bulkasset
         """
 
         u = self.base_url + '/bulkasset'
@@ -63,6 +63,21 @@ class ContentService():
         u = self.base_url + '/checkcontent'
         r = self.session.get(u, json=query, headers={
             'Content-Type': 'application/json'
+        })
+        r.raise_for_status()
+        return r.json()
+
+    def bulkcontent(self, tarball):
+        """
+        Bulk-upload a binary buffer containing multiple envelopes and
+        metadata files within a .tar.gz file.
+
+        https://github.com/deconst/content-service#post-bulkcontent
+        """
+
+        u = self.base_url + '/bulkcontent'
+        r = self.session.post(u, data=tarball, headers={
+            'Content-Type': 'application/tar+gzip'
         })
         r.raise_for_status()
         return r.json()

--- a/submitter/content_service.py
+++ b/submitter/content_service.py
@@ -51,3 +51,18 @@ class ContentService():
         })
         r.raise_for_status()
         return r.json()
+
+    def checkcontent(self, query):
+        """
+        Query the content service with a map of content IDs and the SHA256
+        checksums of their corresponding metadata envelopes.
+
+        https://github.com/deconst/content-service#get-checkcontent
+        """
+
+        u = self.base_url + '/checkcontent'
+        r = self.session.get(u, json=query, headers={
+            'Content-Type': 'application/json'
+        })
+        r.raise_for_status()
+        return r.json()

--- a/submitter/envelope.py
+++ b/submitter/envelope.py
@@ -91,5 +91,17 @@ class EnvelopeSet():
     def append(self, envelope):
         self.envelopes.append(envelope)
 
+    def all(self):
+        """
+        Yield each Envelope.
+        """
+
+        for e in self.envelopes:
+            yield e
+
+    def accept_presence(self, response):
+        for envelope in self.all():
+            envelope.accept_presence(response)
+
     def __len__(self):
         return len(self.envelopes)

--- a/submitter/envelope.py
+++ b/submitter/envelope.py
@@ -67,3 +67,18 @@ class Envelope():
 
         stable = json.dumps(self.document, separators=(',', ':'), sort_keys=True)
         return hashlib.sha256(stable.encode('utf-8')).hexdigest()
+
+
+class EnvelopeSet():
+    """
+    Collection of all metadata Envelopes discovered from disk.
+    """
+
+    def __init__(self):
+        self.envelopes = []
+
+    def append(self, envelope):
+        self.envelopes.append(envelope)
+
+    def __len__(self):
+        return len(self.envelopes)

--- a/submitter/envelope.py
+++ b/submitter/envelope.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+
+import json
+from os.path import basename, splitext
+from urllib.parse import unquote
+
+class Envelope():
+    """
+    A metadata envelope, read from disk.
+    """
+
+    def __init__(self, fname, stream):
+        self.fname = fname
+        self.body = json.load(stream)
+
+    def encoded_content_id(self):
+        return splitext(basename(self.fname))[0]
+
+    def content_id(self):
+        return unquote(self.encoded_content_id())

--- a/submitter/envelope.py
+++ b/submitter/envelope.py
@@ -11,10 +11,46 @@ class Envelope():
 
     def __init__(self, fname, stream):
         self.fname = fname
-        self.body = json.load(stream)
+        self.document = json.load(stream)
 
     def encoded_content_id(self):
         return splitext(basename(self.fname))[0]
 
     def content_id(self):
         return unquote(self.encoded_content_id())
+
+    def apply_asset_offsets(self, asset_set):
+        """
+        If this envelope has an "asset_offsets" attribute, replace each
+        placeholder character with the asset URL and remove that attribute.
+        """
+
+        if 'asset_offsets' not in self.document:
+            return
+
+        paths_by_offset = {}
+        for localpath, offsets in self.document['asset_offsets'].items():
+            for offset in offsets:
+                # TODO warn if there are offset collisions
+                paths_by_offset[offset] = localpath
+
+        body = self.document['body']
+        processed = ''
+        last = 0
+        for offset in sorted(paths_by_offset.keys()):
+            # Append the slice from the end of the last slice to just before
+            # this placeholder.
+            processed += body[last:offset]
+
+            # Insert the asset URL.
+            asset = asset_set[paths_by_offset[offset]]
+            processed += asset.public_url
+
+            # Mark the last occurrence.
+            last = offset + 1
+
+        # Append the rest of the body.
+        processed += body[last:]
+
+        self.document['body'] = processed
+        del self.document['asset_offsets']

--- a/submitter/envelope.py
+++ b/submitter/envelope.py
@@ -16,6 +16,10 @@ class Envelope():
         self.upload_needed = True
 
     def needs_upload(self):
+        """
+        Implemented as a method for consistency with Asset.
+        """
+
         return self.upload_needed
 
     def encoded_content_id(self):
@@ -59,6 +63,13 @@ class Envelope():
 
         self.document['body'] = processed
         del self.document['asset_offsets']
+
+    def accept_presence(self, response):
+        """
+        Accept this Envelope's result from a content check call.
+        """
+
+        self.upload_needed = not response[self.content_id()]
 
     def fingerprint(self):
         """

--- a/submitter/envelope.py
+++ b/submitter/envelope.py
@@ -79,6 +79,25 @@ class Envelope():
         stable = json.dumps(self.document, separators=(',', ':'), sort_keys=True)
         return hashlib.sha256(stable.encode('utf-8')).hexdigest()
 
+    def __repr__(self):
+        return '{}(fname={},document={},upload_needed={})'.format(
+            self.__class__.__name__,
+            self.fname,
+            self.document,
+            self.upload_needed
+        )
+
+    def __str__(self):
+        upload_mark = ''
+        if self.needs_upload():
+            upload_mark = ': *'
+
+        return '{}({}{})'.format(
+            self.__class__.__name__,
+            self.content_id(),
+            upload_mark
+        )
+
 
 class EnvelopeSet():
     """
@@ -132,3 +151,9 @@ class EnvelopeSet():
 
     def __len__(self):
         return len(self.envelopes)
+
+    def __repr__(self):
+        return '{}(envelopes={})'.format(self.__class__.__name__, self.envelopes)
+
+    def __str__(self):
+        return '{}(envelopes x{})'.format(self.__class__.__name__, len(self))

--- a/submitter/envelope.py
+++ b/submitter/envelope.py
@@ -99,6 +99,13 @@ class EnvelopeSet():
         for e in self.envelopes:
             yield e
 
+    def fingerprint_query(self):
+        """
+        Construct a query map of content IDs to normalized envelope fingerprints.
+        """
+
+        return {e.content_id(): e.fingerprint() for e in self.all()}
+
     def accept_presence(self, response):
         for envelope in self.all():
             envelope.accept_presence(response)

--- a/submitter/envelope.py
+++ b/submitter/envelope.py
@@ -76,8 +76,10 @@ class Envelope():
         Compute the SHA256 checksum of a stable representation of this envelope.
         """
 
-        stable = json.dumps(self.document, separators=(',', ':'), sort_keys=True)
-        return hashlib.sha256(stable.encode('utf-8')).hexdigest()
+        return hashlib.sha256(self.serialize().encode('utf-8')).hexdigest()
+
+    def serialize(self):
+        return json.dumps(self.document, separators=(',', ':'), sort_keys=True)
 
     def __repr__(self):
         return '{}(fname={},document={},upload_needed={})'.format(

--- a/submitter/envelope.py
+++ b/submitter/envelope.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import hashlib
 import json
 from os.path import basename, splitext
 from urllib.parse import unquote
@@ -12,6 +13,10 @@ class Envelope():
     def __init__(self, fname, stream):
         self.fname = fname
         self.document = json.load(stream)
+        self.upload_needed = True
+
+    def needs_upload(self):
+        return self.upload_needed
 
     def encoded_content_id(self):
         return splitext(basename(self.fname))[0]
@@ -54,3 +59,11 @@ class Envelope():
 
         self.document['body'] = processed
         del self.document['asset_offsets']
+
+    def fingerprint(self):
+        """
+        Compute the SHA256 checksum of a stable representation of this envelope.
+        """
+
+        stable = json.dumps(self.document, separators=(',', ':'), sort_keys=True)
+        return hashlib.sha256(stable.encode('utf-8')).hexdigest()

--- a/submitter/envelope.py
+++ b/submitter/envelope.py
@@ -127,6 +127,14 @@ class EnvelopeSet():
 
         return {e.content_id(): e.fingerprint() for e in self.all()}
 
+    def apply_asset_offsets(self, asset_set):
+        """
+        Process asset_offsets entries in all known envelopes.
+        """
+
+        for envelope in self.all():
+            envelope.apply_asset_offsets(asset_set)
+
     def accept_presence(self, response):
         for envelope in self.all():
             envelope.accept_presence(response)

--- a/submitter/envelope.py
+++ b/submitter/envelope.py
@@ -110,5 +110,25 @@ class EnvelopeSet():
         for envelope in self.all():
             envelope.accept_presence(response)
 
+    def to_upload(self):
+        """
+        Generate the set of Envelopes that have changed and need to be uploaded
+        to the content service.
+        """
+
+        for envelope in self.all():
+            if envelope.needs_upload():
+                yield envelope
+
+    def to_keep(self):
+        """
+        Generate the set of Envelopes that are already present on the content
+        service, but still exist and should not be deleted.
+        """
+
+        for envelope in self.all():
+            if not envelope.needs_upload():
+                yield envelope
+
     def __len__(self):
         return len(self.envelopes)

--- a/test/config_test.py
+++ b/test/config_test.py
@@ -8,13 +8,15 @@ def test_valid_config():
         'ENVELOPE_DIR': '/envelopes/',
         'ASSET_DIR': '/assets/',
         'CONTENT_SERVICE_URL': 'http://localhost:9000',
-        'CONTENT_SERVICE_APIKEY': '12341234'
+        'CONTENT_SERVICE_APIKEY': '12341234',
+        'CONTENT_ID_BASE': 'https://github.com/org/repo/'
     })
 
     assert_equal(c.envelope_dir, '/envelopes/')
     assert_equal(c.asset_dir, '/assets/')
     assert_equal(c.content_service_url, 'http://localhost:9000')
     assert_equal(c.content_service_apikey, '12341234')
+    assert_equal(c.content_id_base, 'https://github.com/org/repo/')
 
     assert_true(c.is_valid())
     assert_equal(c.missing(), [])
@@ -23,7 +25,8 @@ def test_missing_value():
     c = Config({
         'ENVELOPE_DIR': '/envelopes/',
         'ASSET_DIR': '',
-        'CONTENT_SERVICE_URL': 'http://localhost:9000/'
+        'CONTENT_SERVICE_URL': 'http://localhost:9000/',
+        'CONTENT_ID_BASE': 'https://github.com/org/repo/'
     })
 
     assert_false(c.is_valid())
@@ -36,6 +39,18 @@ def test_normalize_url():
         'ASSET_DIR': '/assets/',
         'CONTENT_SERVICE_APIKEY': '12341234',
         'CONTENT_SERVICE_URL': 'http://with.trailing.slash:9000/',
+        'CONTENT_ID_BASE': 'https://github.com/org/repo/'
     })
 
     assert_equal(c.content_service_url, 'http://with.trailing.slash:9000')
+
+def test_normalize_id_base():
+    c = Config({
+        'ENVELOPE_DIR': '/envelopes/',
+        'ASSET_DIR': '/assets/',
+        'CONTENT_SERVICE_APIKEY': '12341234',
+        'CONTENT_SERVICE_URL': 'http://localhost:9000',
+        'CONTENT_ID_BASE': 'https://github.com/org/repo'
+    })
+
+    assert_equal(c.content_id_base, 'https://github.com/org/repo/')

--- a/test/content_service_test.py
+++ b/test/content_service_test.py
@@ -58,3 +58,29 @@ class TestContentService():
                 'bar/bbb.gif': '/__local_asset__/bbb-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.gif',
                 'foo/aaa.jpg': '/__local_asset__/aaa-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.jpg'
             })
+
+    def test_checkcontent(self):
+        # curl -X PUT -H "Authorization: deconst ${APIKEY}" \
+        #   -H 'Content-Type: application/json' \
+        #   http://dockerdev:9000/content/https%3A%2F%2Fgithub.com%2Forg%2Frepo%2Fone \
+        #   -d '{"title":"one","body":"one"}'
+
+        # echo -n '{"body":"one","title":"one"}' | shasum -a 256
+
+        # curl -X PUT -H "Authorization: deconst ${APIKEY}" \
+        #   -H 'Content-Type: application/json' \
+        #   http://dockerdev:9000/content/https%3A%2F%2Fgithub.com%2Forg%2Frepo%2Ftwo \
+        #   -d '{"title":"two","body":"two"}'
+
+        # echo -n '{"body":"two","title":"two"}' | shasum -a 256
+
+        with self.betamax.use_cassette('checkcontent'):
+            response = self.cs.checkcontent({
+                'https://github.com/org/repo/one': '842d36ad29589a39fc4be06157c5c204a360f98981fc905c0b2a114662172bd8',
+                'https://github.com/org/repo/two': 'f0e62392fc00c71ba3118c91b97c6f2cbfdcd75e8053fe2d9f029ebfcf6c23fe'
+            })
+
+            assert_equal(response, {
+                'https://github.com/org/repo/one': True,
+                'https://github.com/org/repo/two': False
+            })

--- a/test/envelope_test.py
+++ b/test/envelope_test.py
@@ -92,10 +92,10 @@ class TestEnvelopeSet():
 
     def setup(self):
         self.envelope_set = EnvelopeSet()
-        self.e0 = Envelope('https://g.com/a/b/one.json', io.StringIO(
+        self.e0 = Envelope('https%3A%2F%2Fg.com%2Fa%2Fb%2Fone.json', io.StringIO(
             '{"title": "one", "body": "one"}'
         ))
-        self.e1 = Envelope('https://g.com/a/b/two.json', io.StringIO(
+        self.e1 = Envelope('https%3A%2F%2Fg.com%2Fa%2Fb%2Ftwo.json', io.StringIO(
             '{"title": "two", "body": "two"}'
         ))
 
@@ -110,3 +110,12 @@ class TestEnvelopeSet():
 
         self.envelope_set.append(self.e1)
         assert_equal(len(self.envelope_set), 2)
+
+    def test_accept_presence(self):
+        self.envelope_set.accept_presence({
+            'https://g.com/a/b/one': True,
+            'https://g.com/a/b/two': False
+        })
+
+        assert_false(self.e0.needs_upload())
+        assert_true(self.e1.needs_upload())

--- a/test/envelope_test.py
+++ b/test/envelope_test.py
@@ -2,7 +2,8 @@
 
 import io
 
-from nose.tools import assert_equal, assert_not_in, assert_true, assert_false
+from nose.tools import assert_equal, assert_in, assert_not_in, \
+    assert_true, assert_false
 
 from submitter.asset import Asset, AssetSet
 from submitter.envelope import Envelope, EnvelopeSet
@@ -125,3 +126,23 @@ class TestEnvelopeSet():
 
         assert_false(self.e0.needs_upload())
         assert_true(self.e1.needs_upload())
+
+    def test_to_upload(self):
+        self.envelope_set.accept_presence({
+            'https://g.com/a/b/one': True,
+            'https://g.com/a/b/two': False
+        })
+
+        to_upload = [e for e in self.envelope_set.to_upload()]
+        assert_not_in(self.e0, to_upload)
+        assert_in(self.e1, to_upload)
+
+    def test_to_keep(self):
+        self.envelope_set.accept_presence({
+            'https://g.com/a/b/one': True,
+            'https://g.com/a/b/two': False
+        })
+
+        to_keep = [e for e in self.envelope_set.to_keep()]
+        assert_in(self.e0, to_keep)
+        assert_not_in(self.e1, to_keep)

--- a/test/envelope_test.py
+++ b/test/envelope_test.py
@@ -55,3 +55,23 @@ class TestEnvelope():
             'https://assets.horse/one-111.jpg are ' \
             'https://assets.horse/three-333.png some ' \
             'assets https://assets.horse/one-111.jpg</p>')
+
+    def test_fingerprint(self):
+        a = Asset('local/one.jpg', io.BytesIO())
+        asset_set = AssetSet()
+        asset_set.append(a)
+        asset_set.accept_urls({
+            'local/one.jpg': 'https://assets.horse/one-111.jpg'
+        })
+
+        data = io.StringIO('''{
+            "title": "another asset envelope",
+            "body": "<p>The asset URL is X</p>",
+            "asset_offsets": { "local/one.jpg": [20] }
+        }''')
+        e = Envelope('https%3A%2F%2Fgithub.com%2Forg%2Frepo%2Fpage.json', data)
+
+        e.apply_asset_offsets(asset_set)
+
+        # echo -n '{"body":"<p>The asset URL is https://assets.horse/one-111.jpg</p>","title":"another asset envelope"}' | shasum -a 256
+        assert_equal(e.fingerprint(), 'a0e0c4043590530b1d911432c04fc4d238c614b60eeaa9b68632d0791ba96aec')

--- a/test/envelope_test.py
+++ b/test/envelope_test.py
@@ -2,14 +2,15 @@
 
 import io
 
-from nose.tools import assert_equal
+from nose.tools import assert_equal, assert_not_in
 
+from submitter.asset import Asset, AssetSet
 from submitter.envelope import Envelope
 
 class TestEnvelope():
 
     def test_construct(self):
-        data = io.StringIO(r'''{
+        data = io.StringIO('''{
             "title": "aaa",
             "body": "<p>This is an envelope</p>"
         }''')
@@ -17,7 +18,40 @@ class TestEnvelope():
 
         assert_equal(e.encoded_content_id(), 'https%3A%2F%2Fgithub.com%2Forg%2Frepo%2Fpage')
         assert_equal(e.content_id(), 'https://github.com/org/repo/page')
-        assert_equal(e.body, {
+        assert_equal(e.document, {
             'title': 'aaa',
             'body': '<p>This is an envelope</p>'
         })
+
+    def test_apply_offsets(self):
+        a0 = Asset('local/one.jpg', io.BytesIO())
+        a1 = Asset('local/two.gif', io.BytesIO())
+        a2 = Asset('local/three.png', io.BytesIO())
+        asset_set = AssetSet()
+        asset_set.append(a0)
+        asset_set.append(a1)
+        asset_set.append(a2)
+
+        asset_set.accept_urls({
+            'local/one.jpg': 'https://assets.horse/one-111.jpg',
+            'local/two.gif': 'https://assets.horse/two-222.gif',
+            'local/three.png': 'https://assets.horse/three-333.png'
+        })
+
+        data = io.StringIO('''{
+            "title": "envelope with asset references",
+            "body": "<p>Hey everyone here X are X some assets X</p>",
+            "asset_offsets": {
+                "local/one.jpg": [21, 41],
+                "local/three.png": [27]
+            }
+        }''')
+        e = Envelope('https%3A%2F%2Fgithub.com%2Forg%2Frepo%2Fpage.json', data)
+
+        e.apply_asset_offsets(asset_set)
+
+        assert_not_in('asset_offsets', e.document)
+        assert_equal(e.document['body'], '<p>Hey everyone here ' \
+            'https://assets.horse/one-111.jpg are ' \
+            'https://assets.horse/three-333.png some ' \
+            'assets https://assets.horse/one-111.jpg</p>')

--- a/test/envelope_test.py
+++ b/test/envelope_test.py
@@ -5,7 +5,7 @@ import io
 from nose.tools import assert_equal, assert_not_in
 
 from submitter.asset import Asset, AssetSet
-from submitter.envelope import Envelope
+from submitter.envelope import Envelope, EnvelopeSet
 
 class TestEnvelope():
 
@@ -75,3 +75,20 @@ class TestEnvelope():
 
         # echo -n '{"body":"<p>The asset URL is https://assets.horse/one-111.jpg</p>","title":"another asset envelope"}' | shasum -a 256
         assert_equal(e.fingerprint(), 'a0e0c4043590530b1d911432c04fc4d238c614b60eeaa9b68632d0791ba96aec')
+
+class TestEnvelopeSet():
+
+    def test_append(self):
+        envelope_set = EnvelopeSet()
+
+        e0 = Envelope('https://g.com/a/b/one.json', io.StringIO(
+            '{"title": "one", "body": "one"}'
+        ))
+        envelope_set.append(e0)
+        assert_equal(len(envelope_set), 1)
+
+        e1 = Envelope('https://g.com/a/b/two.json', io.StringIO(
+            '{"title": "two", "body": "two"}'
+        ))
+        envelope_set.append(e1)
+        assert_equal(len(envelope_set), 2)

--- a/test/envelope_test.py
+++ b/test/envelope_test.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+
+import io
+
+from nose.tools import assert_equal
+
+from submitter.envelope import Envelope
+
+class TestEnvelope():
+
+    def test_construct(self):
+        data = io.StringIO(r'''{
+            "title": "aaa",
+            "body": "<p>This is an envelope</p>"
+        }''')
+        e = Envelope('https%3A%2F%2Fgithub.com%2Forg%2Frepo%2Fpage.json', data)
+
+        assert_equal(e.encoded_content_id(), 'https%3A%2F%2Fgithub.com%2Forg%2Frepo%2Fpage')
+        assert_equal(e.content_id(), 'https://github.com/org/repo/page')
+        assert_equal(e.body, {
+            'title': 'aaa',
+            'body': '<p>This is an envelope</p>'
+        })

--- a/test/envelope_test.py
+++ b/test/envelope_test.py
@@ -111,6 +111,12 @@ class TestEnvelopeSet():
         self.envelope_set.append(self.e1)
         assert_equal(len(self.envelope_set), 2)
 
+    def test_fingerprint_query(self):
+        assert_equal(self.envelope_set.fingerprint_query(), {
+            'https://g.com/a/b/one': '842d36ad29589a39fc4be06157c5c204a360f98981fc905c0b2a114662172bd8',
+            'https://g.com/a/b/two': 'b00e03c4da0d9ce6b65ae32a384c4cbb893bc13e2c05817b411128f8e118fe0b'
+        })
+
     def test_accept_presence(self):
         self.envelope_set.accept_presence({
             'https://g.com/a/b/one': True,

--- a/test/envelope_test.py
+++ b/test/envelope_test.py
@@ -78,17 +78,23 @@ class TestEnvelope():
 
 class TestEnvelopeSet():
 
-    def test_append(self):
-        envelope_set = EnvelopeSet()
-
-        e0 = Envelope('https://g.com/a/b/one.json', io.StringIO(
+    def setup(self):
+        self.envelope_set = EnvelopeSet()
+        self.e0 = Envelope('https://g.com/a/b/one.json', io.StringIO(
             '{"title": "one", "body": "one"}'
         ))
-        envelope_set.append(e0)
-        assert_equal(len(envelope_set), 1)
-
-        e1 = Envelope('https://g.com/a/b/two.json', io.StringIO(
+        self.e1 = Envelope('https://g.com/a/b/two.json', io.StringIO(
             '{"title": "two", "body": "two"}'
         ))
-        envelope_set.append(e1)
-        assert_equal(len(envelope_set), 2)
+
+        self.envelope_set.append(self.e0)
+        self.envelope_set.append(self.e1)
+
+    def test_append(self):
+        self.envelope_set = EnvelopeSet()
+
+        self.envelope_set.append(self.e0)
+        assert_equal(len(self.envelope_set), 1)
+
+        self.envelope_set.append(self.e1)
+        assert_equal(len(self.envelope_set), 2)

--- a/test/envelope_test.py
+++ b/test/envelope_test.py
@@ -2,7 +2,7 @@
 
 import io
 
-from nose.tools import assert_equal, assert_not_in
+from nose.tools import assert_equal, assert_not_in, assert_true, assert_false
 
 from submitter.asset import Asset, AssetSet
 from submitter.envelope import Envelope, EnvelopeSet
@@ -75,6 +75,18 @@ class TestEnvelope():
 
         # echo -n '{"body":"<p>The asset URL is https://assets.horse/one-111.jpg</p>","title":"another asset envelope"}' | shasum -a 256
         assert_equal(e.fingerprint(), 'a0e0c4043590530b1d911432c04fc4d238c614b60eeaa9b68632d0791ba96aec')
+
+    def test_accept_presence(self):
+        data = io.StringIO('{"title": "a", "body":"a"}')
+        e = Envelope('https%3A%2F%2Fgithub.com%2Forg%2Frepo%2Fpage.json', data)
+        assert_true(e.needs_upload())
+
+        e.accept_presence({ 'https://github.com/org/repo/page': False })
+        assert_true(e.needs_upload())
+
+        e.accept_presence({ 'https://github.com/org/repo/page': True })
+        assert_false(e.needs_upload())
+
 
 class TestEnvelopeSet():
 

--- a/test/fixtures/cassettes/bulkcontent.json
+++ b/test/fixtures/cassettes/bulkcontent.json
@@ -1,0 +1,50 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2016-04-22T12:56:53",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "\u001f\ufffd\b\u0000\ufffd\u001f\u001aW\u0002\ufffd\ufffd\ufffd\ufffd\n\ufffd0\u0014\ufffd\ufffd=\ufffd\f\ufffd\u000b\ufffd)\u0006\ufffdu\ufffd{d\ufffd\u001a\ufffdD'\u0011\u047bw\ufffd\ufffd\ufffd*\n\u0004\ufffd\ufffdc\ufffd\ufffd\ufffdb0\u000e_\ufffd\\\ufffd\ufffd\ufffd\ufffd_\ufffd\ufffd\ufffd\u0295}\u0016\ufffd\ufffdI\u001a\ufffd\u0016\ufffd\ufffdyc\ufffd\ufffd\u0383Cgk\ufffd\u0005#\ufffd8~T1\ufffd\ufffdD\ufffd\ufffd<\u0707\ufffd0\n\ufffdg\ufffd\u0004\ufffd\ufffdm[\ufffd\ufffd\ufffd\ufffd\ufffd\ufffdf\ufffd3\ufffd\ufffd\u8d56\u0001\ufffdv\ufffd;\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\u000f\ufffd\ufffd\ufffdv\ufffd\ufffd'\ufffd\u007f\ufffd\ufffd\u02c0\ufffd\ufffd?t\ufffd\u001f\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000`\u0006\ufffd3\ufffd\ufffd\ufffd\u0000(\u0000\u0000"
+        },
+        "headers": {
+          "Accept": "application/json",
+          "Accept-Encoding": "gzip, deflate",
+          "Authorization": "deconst <APIKEY>",
+          "Connection": "keep-alive",
+          "Content-Length": "185",
+          "Content-Type": "application/tar+gzip",
+          "User-Agent": "submitter/0.0.0"
+        },
+        "method": "POST",
+        "uri": "http://dockerdev:9000/bulkcontent"
+      },
+      "response": {
+        "body": {
+          "encoding": null,
+          "string": "{\"accepted\":2,\"failed\":0,\"deleted\":0}"
+        },
+        "headers": {
+          "Access-Control-Allow-Headers": "Accept, Accept-Version, Content-Length, Content-MD5, Content-Type, Date, Api-Version, Response-Time",
+          "Access-Control-Allow-Methods": "POST",
+          "Access-Control-Allow-Origin": "*",
+          "Access-Control-Expose-Headers": "Api-Version, Request-Id, Response-Time",
+          "Connection": "Keep-Alive",
+          "Content-Length": "37",
+          "Content-MD5": "XzTH1e6XZv8akhGboeUUnw==",
+          "Content-Type": "application/json",
+          "Date": "Fri, 22 Apr 2016 12:56:53 GMT",
+          "Request-Id": "420ea5a3-ba93-46e9-a91e-897f3286749b",
+          "Response-Time": "25",
+          "Server": "content-service"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "http://dockerdev:9000/bulkcontent"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.6.0"
+}

--- a/test/fixtures/cassettes/checkcontent.json
+++ b/test/fixtures/cassettes/checkcontent.json
@@ -1,0 +1,50 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2016-04-22T12:36:38",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"https://github.com/org/repo/one\": \"842d36ad29589a39fc4be06157c5c204a360f98981fc905c0b2a114662172bd8\", \"https://github.com/org/repo/two\": \"f0e62392fc00c71ba3118c91b97c6f2cbfdcd75e8053fe2d9f029ebfcf6c23fe\"}"
+        },
+        "headers": {
+          "Accept": "application/json",
+          "Accept-Encoding": "gzip, deflate",
+          "Authorization": "deconst <APIKEY>",
+          "Connection": "keep-alive",
+          "Content-Length": "206",
+          "Content-Type": "application/json",
+          "User-Agent": "submitter/0.0.0"
+        },
+        "method": "GET",
+        "uri": "http://dockerdev:9000/checkcontent"
+      },
+      "response": {
+        "body": {
+          "encoding": null,
+          "string": "{\"https://github.com/org/repo/one\":true,\"https://github.com/org/repo/two\":false}"
+        },
+        "headers": {
+          "Access-Control-Allow-Headers": "Accept, Accept-Version, Content-Length, Content-MD5, Content-Type, Date, Api-Version, Response-Time",
+          "Access-Control-Allow-Methods": "GET",
+          "Access-Control-Allow-Origin": "*",
+          "Access-Control-Expose-Headers": "Api-Version, Request-Id, Response-Time",
+          "Connection": "Keep-Alive",
+          "Content-Length": "80",
+          "Content-MD5": "pvsdqJHmyxtRqYdKtfGjbA==",
+          "Content-Type": "application/json",
+          "Date": "Fri, 22 Apr 2016 12:36:38 GMT",
+          "Request-Id": "648f7ede-7fee-4aec-9529-a4b9b227d890",
+          "Response-Time": "2",
+          "Server": "content-service"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "http://dockerdev:9000/checkcontent"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.6.0"
+}

--- a/test/fixtures/cassettes/test_submit_envelopes.json
+++ b/test/fixtures/cassettes/test_submit_envelopes.json
@@ -1,0 +1,95 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2016-04-22T14:45:10",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"https://github.com/org/repo/three\": \"669cbcb84005e73e8bbef1ad59655948422843426d4ab36b6ba7439db5a44bcc\", \"https://github.com/org/repo/one\": \"d30228ae5d06eeda45087035b7a84ceb20d83ad7ceafea3eb023a63068b88ea8\", \"https://github.com/org/repo/two\": \"372d06da50365f8626d2fef5bf1322cbdd50633cccce08bc72ace7614b2f92b6\"}"
+        },
+        "headers": {
+          "Accept": "application/json",
+          "Accept-Encoding": "gzip, deflate",
+          "Authorization": "deconst <APIKEY>",
+          "Connection": "keep-alive",
+          "Content-Length": "311",
+          "Content-Type": "application/json",
+          "User-Agent": "submitter/0.0.0"
+        },
+        "method": "GET",
+        "uri": "http://dockerdev:9000/checkcontent"
+      },
+      "response": {
+        "body": {
+          "encoding": null,
+          "string": "{\"https://github.com/org/repo/three\":false,\"https://github.com/org/repo/one\":false,\"https://github.com/org/repo/two\":false}"
+        },
+        "headers": {
+          "Access-Control-Allow-Headers": "Accept, Accept-Version, Content-Length, Content-MD5, Content-Type, Date, Api-Version, Response-Time",
+          "Access-Control-Allow-Methods": "GET",
+          "Access-Control-Allow-Origin": "*",
+          "Access-Control-Expose-Headers": "Api-Version, Request-Id, Response-Time",
+          "Connection": "Keep-Alive",
+          "Content-Length": "123",
+          "Content-MD5": "BrVTWsLPOySSHWojQd7rXA==",
+          "Content-Type": "application/json",
+          "Date": "Fri, 22 Apr 2016 14:45:10 GMT",
+          "Request-Id": "5bab516d-3935-4217-a0e0-80b32e91ca44",
+          "Response-Time": "2",
+          "Server": "content-service"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "http://dockerdev:9000/checkcontent"
+      }
+    },
+    {
+      "recorded_at": "2016-04-22T14:45:10",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "\u001f\ufffd\b\u0000\ufffd8\u001aW\u0002\ufffd\ufffd]k\ufffd0\u0014\ufffd\ufffdS\ufffd\ufffd\ufffdf\ufffdbIV\ufffdP\n+e\ufffd\ufffd\u074da$\ufffd\ufffd\ufffdM,c)\ufffdQ\ufffd\u07e7d\ufffd\u000e\ufffd#\ufffd\ufffd\u059e\u0007aY6\u0208\ufffd\u7576\u0010\u036d\ufffd\ufffd9\u07d6M5\ufffd\u000b\ufffd\ufffd\ufffd0\ufffd\ufffd\ufffd\ufffd\ufffd'\ufffd}z\ufffd=\ufffd\u001f\ufffdgb\ufffd\ufffd\ufffd,f\u0013\ufffd\u000b\ufffd\ufffd\ufffd\"\u007f_\ufffd\u007f\ufffd\u0003M\ufffd\ufffd\ufffd\ufffd\ufffd7\ufffd&\u0000]\u0013Z\ufffd\u06055cU\u0013\ub75d;\ufffde\ufffd\ufffdX\u000f\ufffdg\ufffdq\ufffd\ufffd&\ufffd\ufffd\ufffd\ufffd\u0007\ufffdF\ufffd\ufffd\u000f\ufffd\ufffd\ufffd\ufffd\u007f\ufffd\ufffd%\ufffd?\ufffd\ufffd\ufffd\ufffd'\ufffd\ufffd~C\ufffd\ufffd \u01f0\ufffd\u0010\u001f/\ufffd\ufffd\u051e\"?\rR\ufffd\ufffd!\ufffd\u000f\ufffd\u0016\ufffdN\ufffd\ufffd\ufffd\ufffd<\u001f\ufffd\ufffd\u0304@\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffdtM/\ufffd\ufffd/u\u0013Hj\ufffd\u05a4\ufffd\u001e\ufffd\u0005bZbB\ufffdHXQl\ufffd3\ufffd\ufffd8,\nf\ufffd\ufffd\u0000\ufffd.\ufffd\ufffd\\\ufffdJ\ufffd\ufffdLjS\ufffdR\ufffd\ufffd\u05aa\ufffd\ufffdK\ufffd4 3\ufffdJj\ufffd\ufffdtF\ufffd\\\ufffd\ufffd.W9\ufffd\ufffd<\ufffd\ufffdu\ufffd%\ufffd\ufffd{\u001a\ufffd\ufffdI\ufffd\u000f\ufffd\ufffd\ufffdg\ufffd\u007f\ufffd\ufffdX\ufffdpn\u0002<\ufffdP'\ufffdK\ufffd\ufffd\ufffd\ufffd\ufffdO5\u001e\ufffdt\ufffd\u000b\u0010H\ufffd\ufffd\u0004\ufffd\ufffd\ufffds\ufffd\ufffd}\ufffd`\ufffd.\u01ff\u0018\ufffd\ufffd\u001c\ufffd\ufffd~\ufffd\ufffd_Hu\ufffd\ufffd+<\ufffdO\ufffd\ufffd\u0793\u0684Q\ufffd\ufffd\ufffd\ufffd[k\ufffd~\ufffd\ufffd)\u007f&J\u0018*\ufffd\ufffd(<\ufffd \b\ufffd \b\ufffd \b\ufffd \b\ufffd o\ufffd\u001f\ufffd\ufffd\ufffd\ufffd\u0000(\u0000\u0000"
+        },
+        "headers": {
+          "Accept": "application/json",
+          "Accept-Encoding": "gzip, deflate",
+          "Authorization": "deconst <APIKEY>",
+          "Connection": "keep-alive",
+          "Content-Length": "448",
+          "Content-Type": "application/tar+gzip",
+          "User-Agent": "submitter/0.0.0"
+        },
+        "method": "POST",
+        "uri": "http://dockerdev:9000/bulkcontent"
+      },
+      "response": {
+        "body": {
+          "encoding": null,
+          "string": "{\"accepted\":3,\"failed\":0,\"deleted\":0}"
+        },
+        "headers": {
+          "Access-Control-Allow-Headers": "Accept, Accept-Version, Content-Length, Content-MD5, Content-Type, Date, Api-Version, Response-Time",
+          "Access-Control-Allow-Methods": "POST",
+          "Access-Control-Allow-Origin": "*",
+          "Access-Control-Expose-Headers": "Api-Version, Request-Id, Response-Time",
+          "Connection": "Keep-Alive",
+          "Content-Length": "37",
+          "Content-MD5": "OOqtp1/dh09xLr1Pz93Hfg==",
+          "Content-Type": "application/json",
+          "Date": "Fri, 22 Apr 2016 14:45:10 GMT",
+          "Request-Id": "4204567f-71c4-4699-adbf-0bf2d77bd0a5",
+          "Response-Time": "17",
+          "Server": "content-service"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "http://dockerdev:9000/bulkcontent"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.6.0"
+}

--- a/test/fixtures/envelopes/https%3A%2F%2Fgithub.com%2Forg%2Frepo%2Fone.json
+++ b/test/fixtures/envelopes/https%3A%2F%2Fgithub.com%2Forg%2Frepo%2Fone.json
@@ -1,0 +1,7 @@
+{
+  "title": "one",
+  "body": "<p>This is one here's an asset X</p>",
+  "asset_offsets": {
+    "foo/aaa.jpg": [31]
+  }
+}

--- a/test/fixtures/envelopes/https%3A%2F%2Fgithub.com%2Forg%2Frepo%2Fthree.json
+++ b/test/fixtures/envelopes/https%3A%2F%2Fgithub.com%2Forg%2Frepo%2Fthree.json
@@ -1,0 +1,7 @@
+{
+  "title": "three",
+  "body": "<p>Three X uses the same asset X twice</p>",
+  "asset_offsets": {
+    "foo/aaa.jpg": [9, 31],
+  }
+}

--- a/test/fixtures/envelopes/https%3A%2F%2Fgithub.com%2Forg%2Frepo%2Fthree.json
+++ b/test/fixtures/envelopes/https%3A%2F%2Fgithub.com%2Forg%2Frepo%2Fthree.json
@@ -2,6 +2,6 @@
   "title": "three",
   "body": "<p>Three X uses the same asset X twice</p>",
   "asset_offsets": {
-    "foo/aaa.jpg": [9, 31],
+    "foo/aaa.jpg": [9, 31]
   }
 }

--- a/test/fixtures/envelopes/https%3A%2F%2Fgithub.com%2Forg%2Frepo%2Ftwo.json
+++ b/test/fixtures/envelopes/https%3A%2F%2Fgithub.com%2Forg%2Frepo%2Ftwo.json
@@ -1,0 +1,8 @@
+{
+  "title": "two",
+  "body": "<p>Two has X two X assets</p>",
+  "asset_offsets": {
+    "foo/aaa.jpg": [11],
+    "bar/bbb.gif": [17]
+  }
+}


### PR DESCRIPTION
1. Read metadata envelopes from an `ENVELOPE_DIR`.
2. Process each envelope that contains an `asset_offsets` element. Insert asset public URLs from an `AssetSet` at the appropriate position within the envelope's body and remove `asset_offsets`.
3. Compute a SHA256 checksum from each envelope. Query the `/checkcontent` endpoint of the content service to determine which envelopes must be uploaded and which are unchanged. Make sure that the SHA256 is consistent with the content service's: it should be stably encoded (with sorted object keys) and not include the `asset_offsets` element.
4. Upload all modified envelopes to `/bulkcontent` within a tarball.
