### PR TITLE
Logging output

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,14 @@ Submit prepared JSON documents to the content service.
 
 ### Configuration
 
-All environment variables must be specified.
+These environment variables must all be specified.
 
 * `ENVELOPE_DIR` A flat directory containing a collection of metadata envelopes in files named with the pattern `<url-encoded-content-ID>.json`.
 * `ASSET_DIR` Root of a directory tree containing assets to be uploaded.
 * `CONTENT_SERVICE_URL` Root URL of the content service.
 * `CONTENT_SERVICE_APIKEY` Valid API key for the content service, issued by an administrator.
 * `CONTENT_ID_BASE` Content ID prefix common to the envelopes found in the envelope directory.
+
+These are optional.
+
+* `VERBOSE` Set to a non-empty value to enable debugging output. *default: false*

--- a/submitter/config.py
+++ b/submitter/config.py
@@ -11,6 +11,7 @@ class Config:
         self.content_service_url = env.get('CONTENT_SERVICE_URL')
         self.content_service_apikey = env.get('CONTENT_SERVICE_APIKEY')
         self.content_id_base = env.get('CONTENT_ID_BASE')
+        self.verbose = env.get('VERBOSE') is not None
 
         if self.content_service_url.endswith('/'):
             self.content_service_url = self.content_service_url[:-1]

--- a/submitter/content_service.py
+++ b/submitter/content_service.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
 
+import logging
+from datetime import datetime
+
 from requests import Session
 
 class ContentService():
@@ -30,11 +33,15 @@ class ContentService():
         https://github.com/deconst/content-service#get-checkassets
         """
 
+        logging.debug('Beginning /checkassets request.')
+        start = datetime.utcnow()
         u = self.base_url + '/checkassets'
         r = self.session.get(u, json=query, headers={
             'Content-Type': 'application/json'
         })
         r.raise_for_status()
+        finish = datetime.utcnow()
+        logging.debug('Completed /checkassets request in {}.', finish - start)
         return r.json()
 
     def bulkasset(self, tarball):
@@ -45,11 +52,15 @@ class ContentService():
         https://github.com/deconst/content-service#post-bulkasset
         """
 
+        logging.debug('Beginning /bulkasset request.')
+        start = datetime.utcnow()
         u = self.base_url + '/bulkasset'
         r = self.session.post(u, data=tarball, headers={
             'Content-Type': 'application/tar+gzip'
         })
         r.raise_for_status()
+        finish = datetime.utcnow()
+        logging.debug('Completed /bulkasset request in {}.', finish - start)
         return r.json()
 
     def checkcontent(self, query):
@@ -60,11 +71,15 @@ class ContentService():
         https://github.com/deconst/content-service#get-checkcontent
         """
 
+        logging.debug('Beginning /checkcontent request.')
+        start = datetime.utcnow()
         u = self.base_url + '/checkcontent'
         r = self.session.get(u, json=query, headers={
             'Content-Type': 'application/json'
         })
         r.raise_for_status()
+        finish = datetime.utcnow()
+        logging.debug('Completed /bulkasset request in {}.', finish - start)
         return r.json()
 
     def bulkcontent(self, tarball):
@@ -75,9 +90,13 @@ class ContentService():
         https://github.com/deconst/content-service#post-bulkcontent
         """
 
+        logging.debug('Beginning /bulkcontent request.')
+        start = datetime.utcnow()
         u = self.base_url + '/bulkcontent'
         r = self.session.post(u, data=tarball, headers={
             'Content-Type': 'application/tar+gzip'
         })
         r.raise_for_status()
+        finish = datetime.utcnow()
+        logging.debug('Completed /bulkasset request in {}.', finish - start)
         return r.json()

--- a/submitter/content_service.py
+++ b/submitter/content_service.py
@@ -41,7 +41,7 @@ class ContentService():
         })
         r.raise_for_status()
         finish = datetime.utcnow()
-        logging.debug('Completed /checkassets request in {}.', finish - start)
+        logging.debug('Completed /checkassets request in {}.'.format(finish - start))
         return r.json()
 
     def bulkasset(self, tarball):
@@ -60,7 +60,7 @@ class ContentService():
         })
         r.raise_for_status()
         finish = datetime.utcnow()
-        logging.debug('Completed /bulkasset request in {}.', finish - start)
+        logging.debug('Completed /bulkasset request in {}.'.format(finish - start))
         return r.json()
 
     def checkcontent(self, query):
@@ -79,7 +79,7 @@ class ContentService():
         })
         r.raise_for_status()
         finish = datetime.utcnow()
-        logging.debug('Completed /bulkasset request in {}.', finish - start)
+        logging.debug('Completed /bulkasset request in {}.'.format(finish - start))
         return r.json()
 
     def bulkcontent(self, tarball):
@@ -98,5 +98,5 @@ class ContentService():
         })
         r.raise_for_status()
         finish = datetime.utcnow()
-        logging.debug('Completed /bulkasset request in {}.', finish - start)
+        logging.debug('Completed /bulkasset request in {}.'.format(finish - start))
         return r.json()

--- a/submitter/submit.py
+++ b/submitter/submit.py
@@ -4,6 +4,8 @@ import io
 import json
 import os
 import tarfile
+import logging
+from datetime import datetime
 from os.path import join, relpath
 
 from .asset import Asset, AssetSet
@@ -53,6 +55,8 @@ def submit_assets(directory, content_service):
 
     asset_set = AssetSet()
 
+    logging.debug('Discovering and fingerprinting asset files within [{}].'.format(directory))
+    ts = datetime.utcnow()
     for root, dirs, files in os.walk(directory):
         for fname in files:
             fullpath = join(root, fname)
@@ -60,10 +64,13 @@ def submit_assets(directory, content_service):
             with open(fullpath, 'rb') as af:
                 asset = Asset(localpath, af)
                 asset_set.append(asset)
+    logging.debug('Discovered {} asset files in {}.'.format(len(asset_set), datetime.utcnow() - ts))
 
     check_result = content_service.checkassets(asset_set.fingerprint_query())
     asset_set.accept_urls(check_result)
 
+    logging.debug('Creating asset tarball.')
+    ts = datetime.utcnow()
     asset_archive = io.BytesIO()
     tf = tarfile.open(fileobj=asset_archive, mode='w:gz')
     uploaded = 0
@@ -72,6 +79,7 @@ def submit_assets(directory, content_service):
         tf.add(fullpath, arcname=asset.localpath)
         uploaded += 1
     tf.close()
+    logging.debug('Created tarball containing {} assets in {}.'.format(uploaded, datetime.utcnow() - ts))
 
     upload_result = content_service.bulkasset(asset_archive.getvalue())
     asset_set.accept_urls(upload_result)
@@ -94,6 +102,8 @@ def submit_envelopes(config, directory, asset_set, content_service):
 
     envelope_set = EnvelopeSet()
 
+    logging.debug('Discovering and parsing envelopes within {}.'.format(directory))
+    ts = datetime.utcnow()
     for entry in os.scandir(directory):
         if entry.is_dir():
             # TODO Output a warning
@@ -105,12 +115,14 @@ def submit_envelopes(config, directory, asset_set, content_service):
         with open(entry.path, 'r') as ef:
             envelope = Envelope(entry.path, ef)
             envelope_set.append(envelope)
+    logging.debug('Discovered {} envelopes in {}.'.format(len(envelope_set), datetime.utcnow() - ts))
 
     envelope_set.apply_asset_offsets(asset_set)
 
     check_response = content_service.checkcontent(envelope_set.fingerprint_query())
     envelope_set.accept_presence(check_response)
 
+    logging.debug('Creating envelope tarball.')
     envelope_archive = io.BytesIO()
     tf = tarfile.open(fileobj=envelope_archive, mode='w:gz')
 
@@ -138,6 +150,7 @@ def submit_envelopes(config, directory, asset_set, content_service):
         tf.addfile(envelope_entry, io.BytesIO(envelope_buffer))
 
     tf.close()
+    logging.debug('Created tarball containing {} envelopes in {}.'.format(uploaded, datetime.utcnow() - ts)
 
     upload_response = content_service.bulkcontent(envelope_archive.getvalue())
 

--- a/submitter/submit.py
+++ b/submitter/submit.py
@@ -150,7 +150,7 @@ def submit_envelopes(config, directory, asset_set, content_service):
         tf.addfile(envelope_entry, io.BytesIO(envelope_buffer))
 
     tf.close()
-    logging.debug('Created tarball containing {} envelopes in {}.'.format(uploaded, datetime.utcnow() - ts)
+    logging.debug('Created tarball containing {} envelopes in {}.'.format(uploaded, datetime.utcnow() - ts))
 
     upload_response = content_service.bulkcontent(envelope_archive.getvalue())
 

--- a/test/config_test.py
+++ b/test/config_test.py
@@ -9,7 +9,8 @@ def test_valid_config():
         'ASSET_DIR': '/assets/',
         'CONTENT_SERVICE_URL': 'http://localhost:9000',
         'CONTENT_SERVICE_APIKEY': '12341234',
-        'CONTENT_ID_BASE': 'https://github.com/org/repo/'
+        'CONTENT_ID_BASE': 'https://github.com/org/repo/',
+        'VERBOSE': 'true'
     })
 
     assert_equal(c.envelope_dir, '/envelopes/')
@@ -17,6 +18,7 @@ def test_valid_config():
     assert_equal(c.content_service_url, 'http://localhost:9000')
     assert_equal(c.content_service_apikey, '12341234')
     assert_equal(c.content_id_base, 'https://github.com/org/repo/')
+    assert_true(c.verbose)
 
     assert_true(c.is_valid())
     assert_equal(c.missing(), [])
@@ -54,3 +56,14 @@ def test_normalize_id_base():
     })
 
     assert_equal(c.content_id_base, 'https://github.com/org/repo/')
+
+def test_verbose_defaults_to_false():
+    c = Config({
+        'ENVELOPE_DIR': '/envelopes/',
+        'ASSET_DIR': '/assets/',
+        'CONTENT_SERVICE_APIKEY': '12341234',
+        'CONTENT_SERVICE_URL': 'http://localhost:9000',
+        'CONTENT_ID_BASE': 'https://github.com/org/repo'
+    })
+
+    assert_false(c.verbose)


### PR DESCRIPTION
Log messages during submission to count and time things that are likely to take more than a trivial duration.

Configure the logger to output plain messages so it won't be a mess in the Strider build window.

Fixes #6.
