### PR TITLE
Emit JSON consistent with the content service.

### DIFF
--- a/submitter/envelope.py
+++ b/submitter/envelope.py
@@ -79,7 +79,7 @@ class Envelope():
         return hashlib.sha256(self.serialize().encode('utf-8')).hexdigest()
 
     def serialize(self):
-        return json.dumps(self.document, separators=(',', ':'), sort_keys=True)
+        return json.dumps(self.document, separators=(',', ':'), sort_keys=True, ensure_ascii=False)
 
     def __repr__(self):
         return '{}(fname={},document={},upload_needed={})'.format(


### PR DESCRIPTION
I'm investigating specific envelopes to pinpoint why different checksums are being calculated between the submitter and the content service.
1. Node's `json-stable-stringify` passes non-ASCII Unicode characters through as-is, which is [correct according to the JSON spec](http://www.ietf.org/rfc/rfc4627.txt). Python's `json` module can behave similarly when `ensure_ascii=False` is specified.
   
   > All Unicode characters may be placed within the quotation marks except for the characters that must be escaped: quotation mark, reverse solidus, and the control characters (U+0000 through U+001F).

Related to #11.
